### PR TITLE
map_marker_reply 구조변경

### DIFF
--- a/src/entities/map_marker_reply.entity.ts
+++ b/src/entities/map_marker_reply.entity.ts
@@ -1,6 +1,5 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 
-import { Map } from './map.entity';
 import { Marker } from './marker.entity';
 import { User } from './user.entity';
 
@@ -24,9 +23,6 @@ export class MapMarkerReply {
     user_id: number;
 
     @Column({ type: 'integer' })
-    map_id: number;
-
-    @Column({ type: 'integer' })
     marker_id: number;
 
     @Column({ type: 'varchar', length: 64 })
@@ -38,10 +34,6 @@ export class MapMarkerReply {
     @ManyToOne(() => User)
     @JoinColumn({ name: 'user_id' })
     user?: User;
-
-    @ManyToOne(() => Map)
-    @JoinColumn({ name: 'map_id' })
-    map?: Map;
 
     @ManyToOne(() => Marker)
     @JoinColumn({ name: 'marker_id' })

--- a/src/reply/dto/get_marker_replies.dto.ts
+++ b/src/reply/dto/get_marker_replies.dto.ts
@@ -3,12 +3,14 @@ import { IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
 
 import { MapMarkerReply } from '../../entities/map_marker_reply.entity';
 
-export class GetMarkerRepliesQuery {
+export class GetMarkerRepliesParam {
     @ApiProperty()
     @IsNumber()
     @IsNotEmpty()
     readonly markerId: number;
+}
 
+export class GetMarkerRepliesQuery {
     @ApiProperty({ required: false })
     @IsNumber()
     @IsOptional()
@@ -51,7 +53,7 @@ export class GetMarkerRepliesResponse {
         this.created = replies.created.getTime();
         this.userId = replies.user_id;
         this.userNickName = replies.user.nickname;
-        this.mapId = replies.map_id;
+        this.mapId = replies.marker.map_id;
         this.markerId = replies.marker_id;
         this.message = replies.message;
     }

--- a/src/reply/dto/post_marker_reply.dto.ts
+++ b/src/reply/dto/post_marker_reply.dto.ts
@@ -3,22 +3,19 @@ import { IsNotEmpty, IsNumber, IsString, Length } from 'class-validator';
 
 import { MapMarkerReply } from '../../entities/map_marker_reply.entity';
 
+export class PostMarkerReplyParam {
+    @ApiProperty()
+    @IsNumber()
+    @IsNotEmpty()
+    readonly markerId: number;
+}
+
 export class PostMarkerReplyBody {
     @ApiProperty({ minLength: 1, maxLength: 64 })
     @IsString()
     @IsNotEmpty()
     @Length(1, 64)
     readonly message: string;
-
-    @ApiProperty()
-    @IsNumber()
-    @IsNotEmpty()
-    readonly mapId: number;
-
-    @ApiProperty()
-    @IsNumber()
-    @IsNotEmpty()
-    readonly markerId: number;
 }
 
 export class PostMarkerReplyResponse {
@@ -52,7 +49,7 @@ export class PostMarkerReplyResponse {
         this.created = reply.created.getTime();
         this.message = reply.message;
         this.userId = reply.user_id;
-        this.mapId = reply.map_id;
+        this.mapId = reply.marker.map_id;
         this.markerId = reply.marker_id;
         this.userNickName = reply.user.nickname;
     }

--- a/src/reply/dto/put_marker_reply.dto.ts
+++ b/src/reply/dto/put_marker_reply.dto.ts
@@ -49,7 +49,7 @@ export class PutMarkerReplyResponse {
         this.created = reply.created.getTime();
         this.message = reply.message;
         this.userId = reply.user_id;
-        this.mapId = reply.map_id;
+        this.mapId = reply.marker_id;
         this.markerId = reply.marker_id;
         this.userNickName = reply.user.nickname;
     }

--- a/src/reply/reply.controller.ts
+++ b/src/reply/reply.controller.ts
@@ -4,36 +4,36 @@ import { ApiOkResponse } from '@nestjs/swagger';
 import { AuthUser, User_ } from '../lib/user_decorator';
 import { JwtAuthGuard } from '../lib/jwt';
 import { ReplyService } from './reply.service';
-import { PostMarkerReplyBody, PostMarkerReplyResponse } from './dto/post_marker_reply.dto';
-import { GetMarkerRepliesQuery, GetMarkerRepliesResponse } from './dto/get_marker_replies.dto';
+import { PostMarkerReplyBody, PostMarkerReplyParam, PostMarkerReplyResponse } from './dto/post_marker_reply.dto';
+import { GetMarkerRepliesParam, GetMarkerRepliesQuery, GetMarkerRepliesResponse } from './dto/get_marker_replies.dto';
 import { DeleteMarkerReplyParam } from './dto/delete_marker_reply.dto';
 import { PutMarkerReplyBody, PutMarkerReplyParam } from './dto/put_marker_reply.dto';
 
-@Controller('/map/marker/replies')
+@Controller('/map/marker')
 export class ReplyController {
     constructor(private readonly replyService: ReplyService) {}
 
-    @Get()
+    @Get('/:markerId/replies')
     @ApiOkResponse({ type: [GetMarkerRepliesResponse] })
-    getMarkerReplies(@Query() query: GetMarkerRepliesQuery) {
-        return this.replyService.getMarkerReplies(query);
+    getMarkerReplies(@Param() param: GetMarkerRepliesParam, @Query() query: GetMarkerRepliesQuery) {
+        return this.replyService.getMarkerReplies(param, query);
     }
 
-    @Post()
+    @Post('/:markerId/replies')
     @UseGuards(JwtAuthGuard)
     @ApiOkResponse({ type: PostMarkerReplyResponse })
-    insertMarkerReply(@User_() user: AuthUser, @Body() body: PostMarkerReplyBody) {
-        return this.replyService.insertMarkerReply(user, body);
+    insertMarkerReply(@User_() user: AuthUser, @Param() param: PostMarkerReplyParam, @Body() body: PostMarkerReplyBody) {
+        return this.replyService.insertMarkerReply(user, param, body);
     }
 
-    @Put('/:replyId')
+    @Put('/replies/:replyId')
     @UseGuards(JwtAuthGuard)
     @ApiOkResponse()
     updateMarkerReply(@User_() user: AuthUser, @Param() param: PutMarkerReplyParam, @Body() body: PutMarkerReplyBody) {
         return this.replyService.updateMarkerReply(user, param, body);
     }
 
-    @Delete('/:replyId')
+    @Delete('/replies/:replyId')
     @UseGuards(JwtAuthGuard)
     @ApiOkResponse()
     deleteMarkerReply(@User_() user: AuthUser, @Param() param: DeleteMarkerReplyParam) {

--- a/src/reply/reply.service.ts
+++ b/src/reply/reply.service.ts
@@ -33,7 +33,6 @@ export class ReplyService {
     async insertMarkerReply({ userId }: AuthUser, { markerId }: PostMarkerReplyParam, { message }: PostMarkerReplyBody) {
         const marker = await this.connection.getRepository(Marker).findOne({ id: markerId, active: MarkerActive.Active });
 
-        console.log(marker);
         if (!marker) throw new BadRequestException('Invalid Marker Id');
 
         const map = await this.connection.getRepository(Map).findOne({ id: marker.map_id, active: MapActive.Active });


### PR DESCRIPTION
map_marker_reply table의 map_id 컬럼 삭제

map->marker->reply 순차적으로 종속성이 적용되어야 하는데 
reply에 map_id가 존재함으로서 불필요한 map<->reply간 종속성 발생하는 이슈 수정

map_id가 제거됨으로서 reply 쿼리 일부 변경되었음
