### PR TITLE
aws secret key변경, common constructor 제거

### DIFF
--- a/src/common/common.service.ts
+++ b/src/common/common.service.ts
@@ -1,10 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { Connection } from 'typeorm';
 
 @Injectable()
 export class CommonService {
-    constructor(private readonly connection: Connection) {}
-
     async getServerStatus() {
         return 'healthy';
     }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -10,7 +10,6 @@ export class UserService {
 
     // 유저 썸네일 업로드
     async uploadImage({ userId }: AuthUser, file): Promise<string> {
-        console.log('key');
         await this.connection.getRepository(User).update(
             { id: userId },
             {


### PR DESCRIPTION
aws 기존계정의 일부 권한이 안되서 새 aws계정의 key로 변경 (serverless access 포함된 계정)